### PR TITLE
Cleanup charts

### DIFF
--- a/charts/starship/Chart.yaml
+++ b/charts/starship/Chart.yaml
@@ -10,7 +10,7 @@ maintainers:
   - name: yaxiong-zhao
 
 # Chart version
-version: 0.1.29
+version: 0.0.30
 
 dependencies:
   - name: timescaledb-single


### PR DESCRIPTION
Rename chart to starship
Rename appVersion, which is not used, we use tag directly to control docker image version

Signed-off-by: Yaxiong Zhao <112656580+yaxiong-zhao@users.noreply.github.com>