### PR TITLE
Cleanup: polish image tag logical.

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,7 +256,11 @@ with `--set` flags.
 helm upgrade my-starship tricorder-stable/starship -n tricorder \
     --set service.type=ClusterIP
 
-# Use specified container image tag
+# Use specified container image tag for starship
+helm upgrade my-starship tricorder-stable/starship -n tricorder \
+    --set tag=<a specific tag>
+
+# Use specified container image tag for starship apiSever
 helm upgrade my-starship tricorder-stable/starship -n tricorder \
     --set apiServer.image.tag=<a specific tag>
 ```

--- a/README.md
+++ b/README.md
@@ -258,7 +258,7 @@ helm upgrade my-starship tricorder-stable/starship -n tricorder \
 
 # Use specified container image tag for starship
 helm upgrade my-starship tricorder-stable/starship -n tricorder \
-    --set tag=<a specific tag>
+    --set images.tag=<a specific tag>
 
 # Use specified container image tag for starship apiSever
 helm upgrade my-starship tricorder-stable/starship -n tricorder \

--- a/charts/starship/templates/agent/daemonset.yaml
+++ b/charts/starship/templates/agent/daemonset.yaml
@@ -38,7 +38,7 @@ spec:
         # keep default function here, because .Chart.AppVersion cannot be invoked as function.
         # https://helm.sh/docs/chart_template_guide/functions_and_pipelines/#using-the-default-function
         # If .Values.agent.image.tag is empty, .Values.tag will be used. But if .Values.tag is empty, .Chart.AppVersion will be used as final tag.
-        image: "{{ .Values.agent.image.repository }}:{{ .Values.agent.image.tag | default .Values.tag | default .Chart.AppVersion }}"
+        image: "{{ .Values.agent.image.repository }}:{{ .Values.agent.image.tag | default .Values.images.tag | default .Chart.AppVersion }}"
         args:
           - --module_deployer_address=api-server:50051
           - --pg_url=postgresql://postgres:tricorder@timescaledb:5432/tricorder

--- a/charts/starship/templates/agent/daemonset.yaml
+++ b/charts/starship/templates/agent/daemonset.yaml
@@ -47,7 +47,8 @@ spec:
                 fieldPath: spec.nodeName
         # keep default function here, because .Chart.AppVersion cannot be invoked as function.
         # https://helm.sh/docs/chart_template_guide/functions_and_pipelines/#using-the-default-function
-        image: "{{ .Values.agent.image.repository }}:{{ .Values.agent.image.tag | default .Chart.AppVersion }}"
+        # If .Values.agent.image.tag is empty, .Values.tag will be used. But if .Values.tag is empty, .Chart.AppVersion will be used as final tag.
+        image: "{{ .Values.agent.image.repository }}:{{ .Values.agent.image.tag | default .Values.tag | default .Chart.AppVersion }}"
         args:
           - --module_deployer_address=api-server:50051
           - --pg_url=postgresql://postgres:tricorder@timescaledb:5432/tricorder

--- a/charts/starship/templates/api-server/statefulset.yaml
+++ b/charts/starship/templates/api-server/statefulset.yaml
@@ -31,7 +31,7 @@ spec:
           # keep default function here, because .Chart.AppVersion cannot be invoked as function
           # https://helm.sh/docs/chart_template_guide/functions_and_pipelines/#using-the-default-function
           # If .Values.apiServer.image.tag is empty, .Values.tag will be used. But if .Values.tag is empty, .Chart.AppVersion will be used as final tag.
-          image: "{{ .Values.apiServer.image.repository }}:{{ .Values.apiServer.image.tag | default .Values.tag | default .Chart.AppVersion }}"
+          image: "{{ .Values.apiServer.image.repository }}:{{ .Values.apiServer.image.tag | default .Values.images.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.apiServer.image.pullPolicy }}
           args:
             # TODO(yaxiong): Consider move the args defined in values.yaml into here directly.
@@ -59,7 +59,7 @@ spec:
           # keep default function here, because .Chart.AppVersion cannot be invoked as function 
           # https://helm.sh/docs/chart_template_guide/functions_and_pipelines/#using-the-default-function
           # If .Values.ui.image.tag is empty, .Values.tag will be used. But if .Values.tag is empty, .Chart.AppVersion will be used as final tag.
-          image: "{{ .Values.ui.image.repository }}:{{ .Values.ui.image.tag | default .Values.tag | default .Chart.AppVersion }}"
+          image: "{{ .Values.ui.image.repository }}:{{ .Values.ui.image.tag | default .Values.images.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.ui.image.pullPolicy }}
           env:
           - name: HELM_RELEASE_NAME

--- a/charts/starship/templates/api-server/statefulset.yaml
+++ b/charts/starship/templates/api-server/statefulset.yaml
@@ -30,7 +30,8 @@ spec:
             value: release
           # keep default function here, because .Chart.AppVersion cannot be invoked as function
           # https://helm.sh/docs/chart_template_guide/functions_and_pipelines/#using-the-default-function
-          image: "{{ .Values.apiServer.image.repository }}:{{ .Values.apiServer.image.tag | default .Chart.AppVersion }}"
+          # If .Values.apiServer.image.tag is empty, .Values.tag will be used. But if .Values.tag is empty, .Chart.AppVersion will be used as final tag.
+          image: "{{ .Values.apiServer.image.repository }}:{{ .Values.apiServer.image.tag | default .Values.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.apiServer.image.pullPolicy }}
           args:
             # TODO(yaxiong): Consider move the args defined in values.yaml into here directly.
@@ -57,7 +58,8 @@ spec:
         - name: mgmt-ui
           # keep default function here, because .Chart.AppVersion cannot be invoked as function 
           # https://helm.sh/docs/chart_template_guide/functions_and_pipelines/#using-the-default-function
-          image: "{{ .Values.ui.image.repository }}:{{ .Values.ui.image.tag | default .Chart.AppVersion }}"
+          # If .Values.ui.image.tag is empty, .Values.tag will be used. But if .Values.tag is empty, .Chart.AppVersion will be used as final tag.
+          image: "{{ .Values.ui.image.repository }}:{{ .Values.ui.image.tag | default .Values.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.ui.image.pullPolicy }}
           env:
           - name: HELM_RELEASE_NAME

--- a/charts/starship/values.yaml
+++ b/charts/starship/values.yaml
@@ -6,6 +6,8 @@ imagePullSecrets: []
 nameOverride: ""
 fullnameOverride: ""
 
+# Specifies of starship image's tag whose default is the chart appVersion.
+# If set, starship agent, ui and api server will use this tag.
 images:
   tag: ""
 

--- a/charts/starship/values.yaml
+++ b/charts/starship/values.yaml
@@ -6,7 +6,8 @@ imagePullSecrets: []
 nameOverride: ""
 fullnameOverride: ""
 
-tag: ""
+images:
+  tag: ""
 
 serviceAccount:
   # Specifies whether a service account should be created

--- a/charts/starship/values.yaml
+++ b/charts/starship/values.yaml
@@ -6,6 +6,8 @@ imagePullSecrets: []
 nameOverride: ""
 fullnameOverride: ""
 
+tag: ""
+
 serviceAccount:
   # Specifies whether a service account should be created
   create: true

--- a/docs/README_CN.md
+++ b/docs/README_CN.md
@@ -65,7 +65,8 @@ kubectl -n tricorder port-forward service/my-starship-api-server
 
 ## 使用 Ingress 转发访问Starship 管理界面
 
-Ingress 用于公开从集群外部到集群内服务的 HTTP 和 HTTPS 路由。 使用以下命令创建 Ingress 规则使用 `starship.io` 作为 host，`80` 作为端口访问 Starship。
+Ingress 用于公开从集群外部到集群内服务的 HTTP 和 HTTPS 路由。
+使用以下命令创建 Ingress 规则使用 `starship.io` 作为 host，`80` 作为端口访问 Starship。
 ```shell
 kubectl apply -f - <<EOF
 apiVersion: networking.k8s.io/v1
@@ -88,7 +89,8 @@ spec:
 EOF
 ```
 
-如果你想使用更多的 Ingress 功能，比如 TLS 访问， 请根据 Ingress [文档](https://kubernetes.io/zh-cn/docs/concepts/services-networking/ingress/) 来编写对应的配置。
+如果你想使用更多的 Ingress 功能，比如 TLS 访问，
+请根据 Ingress [文档](https://kubernetes.io/zh-cn/docs/concepts/services-networking/ingress/) 来编写对应的配置。
 
 ## 配置数据留存时间
 

--- a/docs/README_CN.md
+++ b/docs/README_CN.md
@@ -207,7 +207,7 @@ helm upgrade my-starship tricorder-stable/starship -n tricorder \
 
 # 使用特定版本的 Starship
 helm upgrade my-starship tricorder-stable/starship -n tricorder \
-    --set tag=<a specific tag>
+    --set images.tag=<a specific tag>
 
 # 使用特定版本的 Starship apiSever
 helm upgrade my-starship tricorder-stable/starship -n tricorder \

--- a/docs/README_CN.md
+++ b/docs/README_CN.md
@@ -199,12 +199,17 @@ kubectl delete namespace tricorder
 ### 覆盖默认配置
 
 您可以使用--set 参数来覆盖在 charts/starship/Values.yaml 的配置值。
+
 ```
-# Change service type to ClusterIP
+# 将服务类型改成 ClusterIP
 helm upgrade my-starship tricorder-stable/starship -n tricorder \
     --set service.type=ClusterIP
 
-# Use specified container image tag
+# 使用特定版本的 Starship
+helm upgrade my-starship tricorder-stable/starship -n tricorder \
+    --set tag=<a specific tag>
+
+# 使用特定版本的 Starship apiSever
 helm upgrade my-starship tricorder-stable/starship -n tricorder \
     --set apiServer.image.tag=<a specific tag>
 ```
@@ -212,6 +217,7 @@ helm upgrade my-starship tricorder-stable/starship -n tricorder \
 ### 从本地仓库中安装
 
 这个存储库，并用本地路径charts/starship 取代 tricorder-stable/starship.
+
 ```
 git clone https://github.com/tricorder-observability/helm-charts
 git clone git@github.com:tricorder-observability/helm-charts.git

--- a/docs/README_CN.md
+++ b/docs/README_CN.md
@@ -90,7 +90,9 @@ EOF
 ```
 
 如果你想使用更多的 Ingress 功能，比如 TLS 访问，
-请根据 Ingress [文档](https://kubernetes.io/zh-cn/docs/concepts/services-networking/ingress/) 来编写对应的配置。
+请根据 Ingress [文档](
+  https://kubernetes.io/zh-cn/docs/concepts/services-networking/ingress/
+  ) 来编写对应的配置。
 
 ## 配置数据留存时间
 


### PR DESCRIPTION
We now use `{{ .Values.agent.image.tag | default .Values.tag | default .Chart.AppVersion }}` as tag value.

As comments in code,  If `.Values.agent.image.tag` is empty, `.Values.tag` will be used. But if .`Values.tag` is empty, `.Chart.AppVersion` will be used as a final tag.

I tested it locally, It works as expected.